### PR TITLE
fix hotreload problem

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mern-ecommerce-app client",
+  "name": "mern-ecommerce-app-client",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "mern-ecommerce-app client",
+      "name": "mern-ecommerce-app-client",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mern-ecommerce-app client",
+  "name": "mern-ecommerce-app-client",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -12,7 +12,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "WDS_SOCKET_PORT=0 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
according to the nature of port mapping, it makes the HotReload feature from create-react-app not work as expected because HotReload's WebSocket still uses the port assigned from react-scripts. To fix this, we can pass an env variable 'WDS_SOCKET_PORT=0' to react-scripts to allow HotReload's WebSocket client finds port from browser's URL instead of using from react-script